### PR TITLE
Accept lowercase "kB" according to SI standard

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -27,6 +27,7 @@ var (
 
 // ParseBase2Bytes supports both iB and B in base-2 multipliers. That is, KB
 // and KiB are both 1024.
+// However "kB", which is the correct SI spelling of 1000 Bytes, is rejected.
 func ParseBase2Bytes(s string) (Base2Bytes, error) {
 	n, err := ParseUnit(s, bytesUnitMap)
 	if err != nil {
@@ -68,12 +69,13 @@ func ParseMetricBytes(s string) (MetricBytes, error) {
 	return MetricBytes(n), err
 }
 
+// TODO: represents 1000B as uppercase "KB", while SI standard requires "kB".
 func (m MetricBytes) String() string {
 	return ToString(int64(m), 1000, "B", "B")
 }
 
 // ParseStrictBytes supports both iB and B suffixes for base 2 and metric,
-// respectively. That is, KiB represents 1024 and KB represents 1000.
+// respectively. That is, KiB represents 1024 and kB, KB represent 1000.
 func ParseStrictBytes(s string) (int64, error) {
 	n, err := ParseUnit(s, bytesUnitMap)
 	if err != nil {

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -16,6 +16,8 @@ func TestParseBase2Bytes(t *testing.T) {
 	n, err := ParseBase2Bytes("0B")
 	assert.NoError(t, err)
 	assert.Equal(t, 0, int(n))
+	n, err = ParseBase2Bytes("1kB")
+	assert.Error(t, err)
 	n, err = ParseBase2Bytes("1KB")
 	assert.NoError(t, err)
 	assert.Equal(t, 1024, int(n))
@@ -25,10 +27,23 @@ func TestParseBase2Bytes(t *testing.T) {
 	n, err = ParseBase2Bytes("1.5MB")
 	assert.NoError(t, err)
 	assert.Equal(t, 1572864, int(n))
+
+	n, err = ParseBase2Bytes("1kiB")
+	assert.Error(t, err)
+	n, err = ParseBase2Bytes("1KiB")
+	assert.NoError(t, err)
+	assert.Equal(t, 1024, int(n))
+	n, err = ParseBase2Bytes("1MiB1KiB25B")
+	assert.NoError(t, err)
+	assert.Equal(t, 1049625, int(n))
+	n, err = ParseBase2Bytes("1.5MiB")
+	assert.NoError(t, err)
+	assert.Equal(t, 1572864, int(n))
 }
 
 func TestMetricBytesString(t *testing.T) {
 	assert.Equal(t, MetricBytes(0).String(), "0B")
+	// TODO: SI standard prefix is lowercase "kB"
 	assert.Equal(t, MetricBytes(1001).String(), "1KB1B")
 	assert.Equal(t, MetricBytes(1001025).String(), "1MB1KB25B")
 }
@@ -37,6 +52,9 @@ func TestParseMetricBytes(t *testing.T) {
 	n, err := ParseMetricBytes("0B")
 	assert.NoError(t, err)
 	assert.Equal(t, 0, int(n))
+	n, err = ParseMetricBytes("1kB")
+	assert.NoError(t, err)
+	assert.Equal(t, 1000, int(n))
 	n, err = ParseMetricBytes("1KB1B")
 	assert.NoError(t, err)
 	assert.Equal(t, 1001, int(n))
@@ -44,6 +62,40 @@ func TestParseMetricBytes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1001025, int(n))
 	n, err = ParseMetricBytes("1.5MB")
+	assert.NoError(t, err)
+	assert.Equal(t, 1500000, int(n))
+}
+
+func TestParseStrictBytes(t *testing.T) {
+	n, err := ParseStrictBytes("0B")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, int(n))
+
+	n, err = ParseStrictBytes("1kiB")
+	assert.Error(t, err)
+	n, err = ParseStrictBytes("1KiB")
+	assert.NoError(t, err)
+	assert.Equal(t, 1024, int(n))
+	n, err = ParseStrictBytes("1MiB1KiB25B")
+	assert.NoError(t, err)
+	assert.Equal(t, 1049625, int(n))
+	n, err = ParseStrictBytes("1.5MiB")
+	assert.NoError(t, err)
+	assert.Equal(t, 1572864, int(n))
+
+	n, err = ParseStrictBytes("0B")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, int(n))
+	n, err = ParseStrictBytes("1kB")
+	assert.NoError(t, err)
+	assert.Equal(t, 1000, int(n))
+	n, err = ParseStrictBytes("1KB1B")
+	assert.NoError(t, err)
+	assert.Equal(t, 1001, int(n))
+	n, err = ParseStrictBytes("1MB1KB25B")
+	assert.NoError(t, err)
+	assert.Equal(t, 1001025, int(n))
+	n, err = ParseStrictBytes("1.5MB")
 	assert.NoError(t, err)
 	assert.Equal(t, 1500000, int(n))
 }

--- a/si.go
+++ b/si.go
@@ -14,13 +14,37 @@ const (
 )
 
 func MakeUnitMap(suffix, shortSuffix string, scale int64) map[string]float64 {
-	return map[string]float64{
-		shortSuffix:  1,
-		"K" + suffix: float64(scale),
+	res := map[string]float64{
+		shortSuffix: 1,
+		// see below for "k" / "K"
 		"M" + suffix: float64(scale * scale),
 		"G" + suffix: float64(scale * scale * scale),
 		"T" + suffix: float64(scale * scale * scale * scale),
 		"P" + suffix: float64(scale * scale * scale * scale * scale),
 		"E" + suffix: float64(scale * scale * scale * scale * scale * scale),
 	}
+
+	// Standard SI prefixes use lowercase "k" for kilo = 1000.
+	// For compatibility, and to be fool-proof, we accept both "k" and "K" in metric mode.
+	//
+	// However, official binary prefixes are always capitalized - "KiB" -
+	// and we specifically never parse "kB" as 1024B because:
+	//
+	// (1) people pedantic enough to use lowercase according to SI unlikely to abuse "k" to mean 1024 :-)
+	//
+	// (2) Use of capital K for 1024 was an informal tradition predating IEC prefixes:
+	//     "The binary meaning of the kilobyte for 1024 bytes typically uses the symbol KB, with an
+	//     uppercase letter K."
+	//     -- https://en.wikipedia.org/wiki/Kilobyte#Base_2_(1024_bytes)
+	//     "Capitalization of the letter K became the de facto standard for binary notation, although this
+	//     could not be extended to higher powers, and use of the lowercase k did persist.[13][14][15]"
+	//     -- https://en.wikipedia.org/wiki/Binary_prefix#History
+	//     See also the extensive https://en.wikipedia.org/wiki/Timeline_of_binary_prefixes.
+	if scale == 1024 {
+		res["K"+suffix] = float64(scale)
+	} else {
+		res["k"+suffix] = float64(scale)
+		res["K"+suffix] = float64(scale)
+	}
+	return res
 }


### PR DESCRIPTION
Hi, this is a step to align better with standards, where the official prefix for 1000
is a lowercase "k": https://en.wikipedia.org/wiki/kilo-

I made `ParseMetricBytes()`, `ParseStrictBytes()` accept both "KB" = "kB" = 1000B now.
Thus this is backwards compatible.

I decided `ParseBase2Bytes()` should still reject "kB".  Capital "K" for 1024 was prevalent as an informal tradition to distinguish from 1000.  See long comment for discussion & citations :)

Binary prefix "KiB" is always capitalized, no change there.  https://en.wikipedia.org/wiki/Binary_prefix

`MetricBytes.String()` still emits "KB".  That's incorrect but fixing that might break backward compatibility, if someone is feeding output from this library into another system that doesn't recognize metric lowercase "k"...  So I punted on it for now.

@zgalor FYI