### PR TITLE
Implement encoding.TextUnmarshaler for kong support

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -40,6 +40,12 @@ func (b Base2Bytes) String() string {
 	return ToString(int64(b), 1024, "iB", "B")
 }
 
+func (b *Base2Bytes) UnmarshalText(text []byte) error {
+	n, err := ParseBase2Bytes(string(text))
+	*b = n
+	return err
+}
+
 var (
 	metricBytesUnitMap = MakeUnitMap("B", "B", 1000)
 )

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -41,6 +41,36 @@ func TestParseBase2Bytes(t *testing.T) {
 	assert.Equal(t, 1572864, int(n))
 }
 
+func TestBase2BytesUnmarshalText(t *testing.T) {
+	var n Base2Bytes
+	err := n.UnmarshalText([]byte("0B"))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, int(n))
+	err = n.UnmarshalText([]byte("1kB"))
+	assert.Error(t, err)
+	err = n.UnmarshalText([]byte("1KB"))
+	assert.NoError(t, err)
+	assert.Equal(t, 1024, int(n))
+	err = n.UnmarshalText([]byte("1MB1KB25B"))
+	assert.NoError(t, err)
+	assert.Equal(t, 1049625, int(n))
+	err = n.UnmarshalText([]byte("1.5MB"))
+	assert.NoError(t, err)
+	assert.Equal(t, 1572864, int(n))
+
+	err = n.UnmarshalText([]byte("1kiB"))
+	assert.Error(t, err)
+	err = n.UnmarshalText([]byte("1KiB"))
+	assert.NoError(t, err)
+	assert.Equal(t, 1024, int(n))
+	err = n.UnmarshalText([]byte("1MiB1KiB25B"))
+	assert.NoError(t, err)
+	assert.Equal(t, 1049625, int(n))
+	err = n.UnmarshalText([]byte("1.5MiB"))
+	assert.NoError(t, err)
+	assert.Equal(t, 1572864, int(n))
+}
+
 func TestMetricBytesString(t *testing.T) {
 	assert.Equal(t, MetricBytes(0).String(), "0B")
 	// TODO: SI standard prefix is lowercase "kB"


### PR DESCRIPTION
This adds "native" support as data type for kong flags.

As per https://github.com/alecthomas/kong/issues/133