### PR TITLE
Implement encoding.TextMarshaler for json/yaml support

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -40,6 +40,12 @@ func (b Base2Bytes) String() string {
 	return ToString(int64(b), 1024, "iB", "B")
 }
 
+// MarshalText implement encoding.TextMarshaler to process json/yaml.
+func (b Base2Bytes) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+// UnmarshalText implement encoding.TextUnmarshaler to process json/yaml.
 func (b *Base2Bytes) UnmarshalText(text []byte) error {
 	n, err := ParseBase2Bytes(string(text))
 	*b = n

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -1,6 +1,7 @@
 package units
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -128,4 +129,37 @@ func TestParseStrictBytes(t *testing.T) {
 	n, err = ParseStrictBytes("1.5MB")
 	assert.NoError(t, err)
 	assert.Equal(t, 1500000, int(n))
+}
+
+func TestJSON(t *testing.T) {
+	type args struct {
+		b Base2Bytes
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "0B",
+			args: args{
+				b: 0,
+			},
+		},
+		{
+			name: "1B",
+			args: args{
+				b: 1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.args.b)
+			assert.NoError(t, err)
+			var b Base2Bytes
+			err = json.Unmarshal(data, &b)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.args.b.String(), b.String())
+		})
+	}
 }


### PR DESCRIPTION
Fix https://github.com/thanos-io/thanos/issues/4656

Signed-off-by: hanjm <hanjinming@outlook.com>