### PR TITLE
Add Floor()

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -52,9 +52,27 @@ func (b *Base2Bytes) UnmarshalText(text []byte) error {
 	return err
 }
 
-var (
-	metricBytesUnitMap = MakeUnitMap("B", "B", 1000)
-)
+// Floor returns Base2Bytes with all but the largest unit zeroed out. So that e.g. 1GiB1MiB1KiB → 1GiB.
+func (b Base2Bytes) Floor() Base2Bytes {
+	switch {
+	case b > Exbibyte:
+		return (b / Exbibyte) * Exbibyte
+	case b > Pebibyte:
+		return (b / Pebibyte) * Pebibyte
+	case b > Tebibyte:
+		return (b / Tebibyte) * Tebibyte
+	case b > Gibibyte:
+		return (b / Gibibyte) * Gibibyte
+	case b > Mebibyte:
+		return (b / Mebibyte) * Mebibyte
+	case b > Kibibyte:
+		return (b / Kibibyte) * Kibibyte
+	default:
+		return b
+	}
+}
+
+var metricBytesUnitMap = MakeUnitMap("B", "B", 1000)
 
 // MetricBytes are SI byte units (1000 bytes in a kilobyte).
 type MetricBytes SI
@@ -84,6 +102,26 @@ func ParseMetricBytes(s string) (MetricBytes, error) {
 // TODO: represents 1000B as uppercase "KB", while SI standard requires "kB".
 func (m MetricBytes) String() string {
 	return ToString(int64(m), 1000, "B", "B")
+}
+
+// Floor returns MetricBytes with all but the largest unit zeroed out. So that e.g. 1GB1MB1KB → 1GB.
+func (b MetricBytes) Floor() MetricBytes {
+	switch {
+	case b > Exabyte:
+		return (b / Exabyte) * Exabyte
+	case b > Petabyte:
+		return (b / Petabyte) * Petabyte
+	case b > Terabyte:
+		return (b / Terabyte) * Terabyte
+	case b > Gigabyte:
+		return (b / Gigabyte) * Gigabyte
+	case b > Megabyte:
+		return (b / Megabyte) * Megabyte
+	case b > Kilobyte:
+		return (b / Kilobyte) * Kilobyte
+	default:
+		return b
+	}
 }
 
 // ParseStrictBytes supports both iB and B suffixes for base 2 and metric,

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -72,6 +72,17 @@ func TestBase2BytesUnmarshalText(t *testing.T) {
 	assert.Equal(t, 1572864, int(n))
 }
 
+func TestBase2RoundToLargest(t *testing.T) {
+	var n Base2Bytes = KiB
+	assert.Equal(t, "1KiB", n.Floor().String())
+	n = MiB + KiB
+	assert.Equal(t, "1MiB", n.Floor().String())
+	n = GiB + MiB + KiB
+	assert.Equal(t, "1GiB", n.Floor().String())
+	n = 3*GiB + 2*MiB + KiB
+	assert.Equal(t, "3GiB", n.Floor().String())
+}
+
 func TestMetricBytesString(t *testing.T) {
 	assert.Equal(t, MetricBytes(0).String(), "0B")
 	// TODO: SI standard prefix is lowercase "kB"
@@ -129,6 +140,17 @@ func TestParseStrictBytes(t *testing.T) {
 	n, err = ParseStrictBytes("1.5MB")
 	assert.NoError(t, err)
 	assert.Equal(t, 1500000, int(n))
+}
+
+func TestMetricRoundToLargest(t *testing.T) {
+	var n MetricBytes = KB
+	assert.Equal(t, "1KB", n.Floor().String())
+	n = MB + KB
+	assert.Equal(t, "1MB", n.Floor().String())
+	n = GB + MB + KB
+	assert.Equal(t, "1GB", n.Floor().String())
+	n = 3*GB + 2*MB + KB
+	assert.Equal(t, "3GB", n.Floor().String())
 }
 
 func TestJSON(t *testing.T) {


### PR DESCRIPTION
This adds a `Floor()` method to both `Base2Bytes` and `MetricBytes`, which "rounds down" to the largest unit size.

The use-case I'm currently interested in would be logging with approximate, more human-friendly sizes ("10GB" instead of "10GB123MB456KB789B").

WDYT? 