### PR TITLE
Fix int64-limit round-trip: exact parsing and single sign

### DIFF
--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -1,0 +1,54 @@
+package units
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetricBytesMarshalCycle covers two defects around the int64 limits:
+//
+//  1. ParseUnit accumulated into a float64. Unit multipliers reach 1e18 and
+//     2^60, beyond the 53-bit float64 mantissa, so MaxInt64 rounded up on parse
+//     and int64() wrapped it to MinInt64.
+//  2. ToString formatted each component from a signed value, emitting a '-' per
+//     unit for negatives (e.g. "-9EB-223PB-..."), a string it could not itself
+//     parse.
+func TestMetricBytesMarshalCycle(t *testing.T) {
+	values := []int64{
+		0,
+		1,
+		-1,
+		1000,
+		-1000,
+		math.MaxInt64,
+		math.MinInt64,
+	}
+
+	for _, v := range values {
+		s := MetricBytes(v).String()
+
+		back, err := ParseStrictBytes(s)
+		require.NoErrorf(t, err, "failed to parse %q (from %d)", s, v)
+		assert.Equalf(t, v, back, "round-trip mismatch via %q", s)
+	}
+}
+
+// TestToStringSingleSign guards defect (2): a negative value carries exactly one
+// leading '-', not one per unit component.
+func TestToStringSingleSign(t *testing.T) {
+	assert.Equal(t, "-9EB223PB372TB36GB854MB775KB808B", MetricBytes(math.MinInt64).String())
+	assert.Equal(t, "9EB223PB372TB36GB854MB775KB807B", MetricBytes(math.MaxInt64).String())
+	assert.Equal(t, "-1KB1B", MetricBytes(-1001).String())
+	assert.Equal(t, "-1KiB1B", Base2Bytes(-1025).String())
+}
+
+// TestParseNoFloatOverflow guards defect (1): the exact MaxInt64 string parses
+// back to MaxInt64 instead of overflowing to MinInt64.
+func TestParseNoFloatOverflow(t *testing.T) {
+	n, err := ParseStrictBytes("9EB223PB372TB36GB854MB775KB807B")
+	require.NoError(t, err)
+	assert.Equal(t, int64(math.MaxInt64), n)
+}

--- a/si.go
+++ b/si.go
@@ -13,15 +13,15 @@ const (
 	Exa     = Peta * 1000
 )
 
-func MakeUnitMap(suffix, shortSuffix string, scale int64) map[string]float64 {
-	res := map[string]float64{
+func MakeUnitMap(suffix, shortSuffix string, scale int64) map[string]int64 {
+	res := map[string]int64{
 		shortSuffix: 1,
 		// see below for "k" / "K"
-		"M" + suffix: float64(scale * scale),
-		"G" + suffix: float64(scale * scale * scale),
-		"T" + suffix: float64(scale * scale * scale * scale),
-		"P" + suffix: float64(scale * scale * scale * scale * scale),
-		"E" + suffix: float64(scale * scale * scale * scale * scale * scale),
+		"M" + suffix: scale * scale,
+		"G" + suffix: scale * scale * scale,
+		"T" + suffix: scale * scale * scale * scale,
+		"P" + suffix: scale * scale * scale * scale * scale,
+		"E" + suffix: scale * scale * scale * scale * scale * scale,
 	}
 
 	// Standard SI prefixes use lowercase "k" for kilo = 1000.
@@ -41,10 +41,10 @@ func MakeUnitMap(suffix, shortSuffix string, scale int64) map[string]float64 {
 	//     -- https://en.wikipedia.org/wiki/Binary_prefix#History
 	//     See also the extensive https://en.wikipedia.org/wiki/Timeline_of_binary_prefixes.
 	if scale == 1024 {
-		res["K"+suffix] = float64(scale)
+		res["K"+suffix] = scale
 	} else {
-		res["k"+suffix] = float64(scale)
-		res["K"+suffix] = float64(scale)
+		res["k"+suffix] = scale
+		res["K"+suffix] = scale
 	}
 	return res
 }

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package units
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 )
 
@@ -13,20 +14,38 @@ var (
 func ToString(n int64, scale int64, suffix, baseSuffix string) string {
 	mn := len(siUnits)
 	out := make([]string, mn)
+
+	// Format the unsigned magnitude and prepend a single '-' for negatives.
+	// Using the signed value directly emits a '-' per component (n%scale is
+	// negative for every unit, e.g. "-9EB-223PB-..."), which is unparseable.
+	// The magnitude is held in uint64 so math.MinInt64 is representable (its
+	// negation overflows int64).
+	neg := n < 0
+	mag := uint64(n)
+	if neg {
+		mag = -mag
+	}
+	uscale := uint64(scale)
+
 	for i, m := range siUnits {
-		if n%scale != 0 || i == 0 && n == 0 {
+		if mag%uscale != 0 || i == 0 && mag == 0 {
 			s := suffix
 			if i == 0 {
 				s = baseSuffix
 			}
-			out[mn-1-i] = fmt.Sprintf("%d%s%s", n%scale, m, s)
+			out[mn-1-i] = fmt.Sprintf("%d%s%s", mag%uscale, m, s)
 		}
-		n /= scale
-		if n == 0 {
+		mag /= uscale
+		if mag == 0 {
 			break
 		}
 	}
-	return strings.Join(out, "")
+
+	res := strings.Join(out, "")
+	if neg {
+		res = "-" + res
+	}
+	return res
 }
 
 // Below code ripped straight from http://golang.org/src/pkg/time/format.go?s=33392:33438#L1123
@@ -49,10 +68,14 @@ func leadingInt(s string) (x int64, rem string, err error) {
 	return x, s[i:], nil
 }
 
-func ParseUnit(s string, unitMap map[string]float64) (int64, error) {
+// ParseUnit accumulates with exact rational arithmetic (math/big) rather than
+// float64: unit multipliers reach 1000^6 (1e18) and 1024^6 (2^60), both beyond
+// the 53-bit float64 mantissa, so a float64 accumulator loses precision near the
+// int64 limits and can round MaxInt64 up to MinInt64 on a round-trip.
+func ParseUnit(s string, unitMap map[string]int64) (int64, error) {
 	// [-+]?([0-9]*(\.[0-9]*)?[a-z]+)+
 	orig := s
-	f := float64(0)
+	f := new(big.Rat)
 	neg := false
 
 	// Consume [-+]?
@@ -71,7 +94,7 @@ func ParseUnit(s string, unitMap map[string]float64) (int64, error) {
 		return 0, errors.New("units: invalid " + orig)
 	}
 	for s != "" {
-		g := float64(0) // this element of the sequence
+		g := new(big.Rat) // this element of the sequence
 
 		var x int64
 		var err error
@@ -86,7 +109,7 @@ func ParseUnit(s string, unitMap map[string]float64) (int64, error) {
 		if err != nil {
 			return 0, errors.New("units: invalid " + orig)
 		}
-		g = float64(x)
+		g.SetInt64(x)
 		pre := pl != len(s) // whether we consumed anything before a period
 
 		// Consume (\.[0-9]*)?
@@ -98,11 +121,11 @@ func ParseUnit(s string, unitMap map[string]float64) (int64, error) {
 			if err != nil {
 				return 0, errors.New("units: invalid " + orig)
 			}
-			scale := 1.0
+			scale := int64(1)
 			for n := pl - len(s); n > 0; n-- {
 				scale *= 10
 			}
-			g += float64(x) / scale
+			g.Add(g, new(big.Rat).SetFrac(big.NewInt(x), big.NewInt(scale)))
 			post = pl != len(s)
 		}
 		if !pre && !post {
@@ -125,14 +148,18 @@ func ParseUnit(s string, unitMap map[string]float64) (int64, error) {
 			return 0, errors.New("units: unknown unit " + u + " in " + orig)
 		}
 
-		f += g * unit
+		g.Mul(g, new(big.Rat).SetInt64(unit))
+		f.Add(f, g)
 	}
 
 	if neg {
-		f = -f
+		f.Neg(f)
 	}
-	if f < float64(-1<<63) || f > float64(1<<63-1) {
+	// Truncate toward zero (preserving the historical int64(f) behaviour for
+	// fractional byte values) with strict overflow detection.
+	res := new(big.Int).Quo(f.Num(), f.Denom())
+	if !res.IsInt64() {
 		return 0, errors.New("units: overflow parsing unit")
 	}
-	return int64(f), nil
+	return res.Int64(), nil
 }


### PR DESCRIPTION
Two defects near the int64 limits:

- ParseUnit accumulated into a float64. Unit multipliers reach 1000^6 (1e18) and 1024^6 (2^60), both beyond the 53-bit float64 mantissa, so MaxInt64 rounded up on parse and int64() wrapped the result to MinInt64. Accumulate with math/big instead and truncate toward zero with strict overflow detection.

- ToString formatted each component from the signed value, so negatives emitted a '-' per unit (e.g. "-9EB-223PB-...") — a string ToString's own parser rejects. Format the unsigned magnitude (uint64, so MinInt64 is representable) and prepend a single leading '-'.

MakeUnitMap now returns map[string]int64 so multipliers stay exact.