### PR TITLE
Reject unit values at the exclusive int64 upper bound

### DIFF
--- a/util.go
+++ b/util.go
@@ -131,7 +131,7 @@ func ParseUnit(s string, unitMap map[string]float64) (int64, error) {
 	if neg {
 		f = -f
 	}
-	if f < float64(-1<<63) || f > float64(1<<63-1) {
+	if f < -0x1p63 || f >= 0x1p63 {
 		return 0, errors.New("units: overflow parsing unit")
 	}
 	return int64(f), nil

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,30 @@
+package units
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseUnitInt64Boundary(t *testing.T) {
+	for _, input := range []string{"8EiB", "4EiB4EiB", "9EiB", "-9EiB"} {
+		t.Run(input, func(t *testing.T) {
+			_, err := ParseUnit(input, bytesUnitMap)
+			assert.EqualError(t, err, "units: overflow parsing unit")
+		})
+	}
+	for _, tc := range []struct {
+		input string
+		want  int64
+	}{
+		{"7EiB", 7 << 60},
+		{"-7EiB", -7 << 60},
+		{"-8EiB", -1 << 63},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := ParseUnit(tc.input, bytesUnitMap)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
`ParseUnit("8EiB", MakeUnitMap("iB", "B", 1024))` returns `math.MinInt64` without an error. The upper-bound check converts `MaxInt64` to `float64`, which rounds it to 2^63, then allows equality before converting the result to `int64`.

Make the positive bound exclusive at 2^63 while retaining the inclusive negative bound at -2^63. This also catches the same overflow when multiple components sum to the boundary (`4EiB4EiB`). The exported types and unit-map representation stay unchanged.

Related to #18. Regression tests cover both limits, larger positive and negative values, and values inside the range. Two cases fail before the fix. `go test -race -cover ./...`, `go vet ./...`, and `staticcheck ./...` pass with Go 1.27.1.
